### PR TITLE
fix: adjust imports for gqlgen generated files

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,25 +130,10 @@ Results in
 }
 ```
 
-To create offr you must set the Authorization header
+To create offer you must set the Authorization header
 ```
 {
   "Authorization": "" // use your own generated token
 }
 ```
 Try again you should be able to create a new offer
-
-
-### Known Issues
-
-```bash
-$ go run server.go
-graph/schema.resolvers.go:9:2: package gqlgen/graph/generated is not in GOROOT (/usr/local/opt/go/libexec/src/gqlgen/graph/generated)
-graph/schema.resolvers.go:10:2: package gqlgen/graph/model is not in GOROOT (/usr/local/opt/go/libexec/src/gqlgen/graph/model)
-graph/schema.resolvers.go:11:2: package gqlgen/internal/auth is not in GOROOT (/usr/local/opt/go/libexec/src/gqlgen/internal/auth)
-graph/schema.resolvers.go:12:2: package gqlgen/internal/offers is not in GOROOT (/usr/local/opt/go/libexec/src/gqlgen/internal/offers)
-graph/schema.resolvers.go:13:2: package gqlgen/internal/pkg/jwt is not in GOROOT (/usr/local/opt/go/libexec/src/gqlgen/internal/pkg/jwt)
-graph/schema.resolvers.go:14:2: package gqlgen/internal/users is not in GOROOT (/usr/local/opt/go/libexec/src/gqlgen/internal/users)
-```
-
-Help needed to solve this dependency issues that i do not understand yet

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -35,7 +35,7 @@ resolver:
 # gqlgen will search for any type names in the schema in these go packages
 # if they match it will use them, otherwise it will generate them.
 autobind:
-  - "gqlgen/graph/model"
+  - "github.com/advenjourney/api/graph/model"
 
 # This section declares type mapping between the GraphQL and go type systems
 #

--- a/graph/generated/generated.go
+++ b/graph/generated/generated.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"gqlgen/graph/model"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -15,6 +14,8 @@ import (
 	"github.com/99designs/gqlgen/graphql/introspection"
 	gqlparser "github.com/vektah/gqlparser/v2"
 	"github.com/vektah/gqlparser/v2/ast"
+
+	"github.com/advenjourney/api/graph/model"
 )
 
 // region    ************************** generated!.gotpl **************************

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -6,13 +6,14 @@ package graph
 import (
 	"context"
 	"fmt"
-	"gqlgen/graph/generated"
-	"gqlgen/graph/model"
-	"gqlgen/internal/auth"
-	"gqlgen/internal/offers"
-	"gqlgen/internal/pkg/jwt"
-	"gqlgen/internal/users"
 	"strconv"
+
+	"github.com/advenjourney/api/graph/generated"
+	"github.com/advenjourney/api/graph/model"
+	"github.com/advenjourney/api/internal/auth"
+	"github.com/advenjourney/api/internal/offers"
+	"github.com/advenjourney/api/internal/users"
+	"github.com/advenjourney/api/pkg/jwt"
 )
 
 func (r *mutationResolver) CreateOffer(ctx context.Context, input model.NewOffer) (*model.Offer, error) {
@@ -21,7 +22,7 @@ func (r *mutationResolver) CreateOffer(ctx context.Context, input model.NewOffer
 		return &model.Offer{}, fmt.Errorf("access denied")
 	}
 
-	var offer offer.Offer
+	var offer offers.Offer
 	offer.Description = input.Description
 	offer.Location = input.Location
 	offer.TitleImageURL = input.TitleImageURL


### PR DESCRIPTION
# Motivation
Prior to this change, the paths were not aligned for the imports and there were a lot of errors encountered when trying to run the application

# Description

Adjust the the imports in the generated files, updated `gqlgen.yml` to reference correct autoimports and remove note from README