### PR TITLE
build: fixed the build for alpline based containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+bin
+dist

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ NAME := api
 IMPORT := github.com/advenjourney/$(NAME)
 BIN := bin
 DIST := dist
-GO := go
+GO := CGO_ENABLED=0 go
 CONTAINER_PREFIX := advenjourney
 
 ifeq ($(OS), Windows_NT)

--- a/cmd/api/Dockerfile
+++ b/cmd/api/Dockerfile
@@ -7,7 +7,6 @@ RUN make clean && make build
 # final stage
 FROM alpine:3.9
 RUN apk add --no-cache ca-certificates
-
-WORKDIR /app
-COPY --from=builder /src/bin/api /app/
-ENTRYPOINT ["./api"]
+WORKDIR app
+COPY --from=builder /src/bin/api /app/api
+ENTRYPOINT ["/app/api"]


### PR DESCRIPTION
# Motivation
By ensuring we built with CGO disabled, the resulting binary
will become cross compatible and can thus run on alpine


# Description
Prior to this change, the server would not start with the container